### PR TITLE
Fix stationlist page

### DIFF
--- a/stationlist.md
+++ b/stationlist.md
@@ -5,9 +5,10 @@ group: "not_in_local_navigation"
 order: 5
 ---
 <div class="row padding-bottom-xlarge bgbox primary">
-
-    <h1><strong>A List of All The Stations!</h1>
+	<div class="columns medium-11 columns medium-push-1 padding-top-xlarge">
+    <h1><strong>A List of All The Stations!</strong></h1>
          <p>To see the locaion of the stations on map, <a href="http://www.allthestations.co.uk/map/">goto the map page here</a>.</p>
+	</div>
 </div>
 
 <div class="row padding-bottom-xlarge padding-top-xlarge">


### PR DESCRIPTION
Adds a missing closing tag on the stationslist page! Also added back a container div, which I think keeps the layout tidy:

![image](https://user-images.githubusercontent.com/6097064/103466688-ff366c80-4d3e-11eb-87a1-a2f8ba59804c.png)
